### PR TITLE
fix: Refresh Home view when returning from background

### DIFF
--- a/Swiftfin tvOS/App/SwiftfinApp.swift
+++ b/Swiftfin tvOS/App/SwiftfinApp.swift
@@ -74,6 +74,10 @@ struct SwiftfinApp: App {
                         Defaults[.lastSignedInUserID] = .signedOut
                         Container.shared.currentUserSession.reset()
                         Notifications[.didSignOut].post()
+                    } else {
+                        // Refresh data after returning from background to pick up
+                        // watch progress from other Jellyfin clients
+                        Notifications[.didRequestGlobalRefresh].post()
                     }
                 }
         }

--- a/Swiftfin tvOS/Views/HomeView/HomeView.swift
+++ b/Swiftfin tvOS/Views/HomeView/HomeView.swift
@@ -78,5 +78,8 @@ struct HomeView: View {
                 viewModel.notificationsReceived.remove(.itemMetadataDidChange)
             }
         }
+        .onReceive(Notifications[.didRequestGlobalRefresh].publisher) { _ in
+            viewModel.send(.backgroundRefresh)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Posts `didRequestGlobalRefresh` notification when app returns from background
- HomeView listens for this notification and triggers a background refresh
- Ensures "Up Next" and "Continue Watching" reflect watch progress from other Jellyfin clients

## Test plan
- [ ] Launch Reefy on tvOS, note current "Up Next" items
- [ ] Watch content on another Jellyfin client (web/phone)
- [ ] Press Home on Apple TV, wait a few seconds, return to Reefy
- [ ] Verify Home view refreshes and shows newly-watched content

Fixes #6

🤖 Generated with [Claude Code](https://claude.ai/code)