### PR TITLE
fix(player): map audio/subtitle track selection to container order for VLC

### DIFF
--- a/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem.swift
@@ -123,14 +123,20 @@ class MediaPlayerItem: ViewModel, MediaPlayerObserver {
 
         // Select audio stream based on user's preferred language, falling back to server default,
         // then first available audio track. Avoid using -1 for audio, as VLC treats it as disabled.
+        // defaultAudioStreamIndex is in server index space; map by position within the audio
+        // list like initialSubtitleStreamIndex does.
         let preferredLanguage = Defaults[.VideoPlayer.Audio.preferredLanguage]
+        let originalAudioStreams = (mediaSource.mediaStreams ?? [])
+            .filter { $0.type == .audio && !($0.isExternal ?? false) }
+
         if let preferredStream = audioStreams.first(where: { $0.language?.lowercased() == preferredLanguage.lowercased() }) {
             selectedAudioStreamIndex = preferredStream.index
         } else if let defaultIndex = mediaSource.defaultAudioStreamIndex,
                   defaultIndex >= 0,
-                  audioStreams.contains(where: { $0.index == defaultIndex })
+                  let position = originalAudioStreams.firstIndex(where: { $0.index == defaultIndex }),
+                  position < audioStreams.count
         {
-            selectedAudioStreamIndex = defaultIndex
+            selectedAudioStreamIndex = audioStreams[position].index
         } else {
             selectedAudioStreamIndex = audioStreams.first?.index
         }
@@ -192,6 +198,30 @@ class MediaPlayerItem: ViewModel, MediaPlayerObserver {
         }
 
         return mediaSource.defaultSubtitleStreamIndex ?? -1
+    }
+
+    /// The VLC track index for an audio stream in the adjusted index space.
+    ///
+    /// VLC numbers tracks by container order, while `adjustedTrackIndexes`
+    /// renumbers internal tracks video-first. Files with audio as the first
+    /// track (common in iTunes-style MP4s) would otherwise request a track
+    /// VLC doesn't have, which silently disables audio (#61). Transcoded
+    /// streams are muxed video-first by the server, so the adjusted index
+    /// already matches.
+    func vlcAudioTrackIndex(forAdjustedIndex adjustedIndex: Int?) -> Int? {
+        guard let adjustedIndex else { return nil }
+        guard mediaSource.transcodingURL == nil else { return adjustedIndex }
+
+        guard let position = audioStreams.firstIndex(where: { $0.index == adjustedIndex }) else {
+            return adjustedIndex
+        }
+
+        let originalAudioStreams = (mediaSource.mediaStreams ?? [])
+            .filter { $0.type == .audio && !($0.isExternal ?? false) }
+
+        guard position < originalAudioStreams.count else { return adjustedIndex }
+
+        return originalAudioStreams[position].index
     }
 
     // MARK: sticky subtitle selection

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem.swift
@@ -224,6 +224,30 @@ class MediaPlayerItem: ViewModel, MediaPlayerObserver {
         return originalAudioStreams[position].index
     }
 
+    /// The VLC track index for a subtitle stream in the adjusted index space.
+    ///
+    /// Internal subtitles map by position to their original container index,
+    /// mirroring `vlcAudioTrackIndex(forAdjustedIndex:)`. External subtitles
+    /// load as playback slaves, which VLC numbers after the container tracks,
+    /// the same relative spot the adjusted space assigns them, so they pass
+    /// through unchanged, as do -1 (off) and transcoded streams.
+    func vlcSubtitleTrackIndex(forAdjustedIndex adjustedIndex: Int?) -> Int? {
+        guard let adjustedIndex else { return nil }
+        guard adjustedIndex >= 0 else { return adjustedIndex }
+        guard mediaSource.transcodingURL == nil else { return adjustedIndex }
+
+        guard let position = subtitleStreams.firstIndex(where: { $0.index == adjustedIndex }),
+              !(subtitleStreams[position].isExternal ?? false)
+        else { return adjustedIndex }
+
+        let originalSubtitleStreams = (mediaSource.mediaStreams ?? [])
+            .filter { $0.type == .subtitle && !($0.isExternal ?? false) }
+
+        guard position < originalSubtitleStreams.count else { return adjustedIndex }
+
+        return originalSubtitleStreams[position].index
+    }
+
     // MARK: sticky subtitle selection
 
     /// Key for the remembered subtitle choice, shared by all episodes of a series.

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerItem/MediaPlayerItem.swift
@@ -248,6 +248,54 @@ class MediaPlayerItem: ViewModel, MediaPlayerObserver {
         return originalSubtitleStreams[position].index
     }
 
+    /// The original server-space index for an audio stream in the adjusted
+    /// index space, for playback reporting. Reverses the adjusted renumbering
+    /// by position; a transcode only carries the server-selected audio track.
+    func serverAudioStreamIndex(forAdjustedIndex adjustedIndex: Int?) -> Int? {
+        guard let adjustedIndex else { return nil }
+        guard adjustedIndex >= 0 else { return adjustedIndex }
+
+        guard let position = audioStreams.firstIndex(where: { $0.index == adjustedIndex }) else {
+            return adjustedIndex
+        }
+
+        let streams = mediaSource.mediaStreams ?? []
+        let internalAudio = streams.filter { $0.type == .audio && !($0.isExternal ?? false) }
+        let externalAudio = streams.filter { $0.type == .audio && ($0.isExternal ?? false) }
+
+        let original: [MediaStream]
+        if mediaSource.transcodingURL == nil {
+            original = internalAudio + externalAudio
+        } else {
+            let selected = mediaSource.defaultAudioStreamIndex ?? 0
+            original = internalAudio.filter { $0.index == selected } + externalAudio
+        }
+
+        guard position < original.count else { return adjustedIndex }
+
+        return original[position].index
+    }
+
+    /// The original server-space index for a subtitle stream in the adjusted
+    /// index space, for playback reporting. Subtitle ordering is internal
+    /// then external for both direct play and transcode.
+    func serverSubtitleStreamIndex(forAdjustedIndex adjustedIndex: Int?) -> Int? {
+        guard let adjustedIndex else { return nil }
+        guard adjustedIndex >= 0 else { return adjustedIndex }
+
+        guard let position = subtitleStreams.firstIndex(where: { $0.index == adjustedIndex }) else {
+            return adjustedIndex
+        }
+
+        let streams = mediaSource.mediaStreams ?? []
+        let original = streams.filter { $0.type == .subtitle && !($0.isExternal ?? false) }
+            + streams.filter { $0.type == .subtitle && ($0.isExternal ?? false) }
+
+        guard position < original.count else { return adjustedIndex }
+
+        return original[position].index
+    }
+
     // MARK: sticky subtitle selection
 
     /// Key for the remembered subtitle choice, shared by all episodes of a series.

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
@@ -84,7 +84,8 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
     }
 
     func setSubtitleStream(_ stream: MediaStream) {
-        vlcUIProxy.setSubtitleTrack(.absolute(stream.index ?? -1))
+        let index = manager?.playbackItem?.vlcSubtitleTrackIndex(forAdjustedIndex: stream.index) ?? stream.index
+        vlcUIProxy.setSubtitleTrack(.absolute(index ?? -1))
     }
 
     func setAspectFill(_ aspectFill: Bool) {
@@ -193,7 +194,7 @@ extension VLCMediaPlayerProxy {
                 } else {
                     configuration.audioIndex = .auto
                 }
-                if let index = item.selectedSubtitleStreamIndex {
+                if let index = item.vlcSubtitleTrackIndex(forAdjustedIndex: item.selectedSubtitleStreamIndex) {
                     configuration.subtitleIndex = .absolute(index)
                 } else {
                     configuration.subtitleIndex = .absolute(mediaSource.defaultSubtitleStreamIndex ?? -1)

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
@@ -75,7 +75,8 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
     }
 
     func setAudioStream(_ stream: MediaStream) {
-        if let index = stream.index, index >= 0 {
+        let index = manager?.playbackItem?.vlcAudioTrackIndex(forAdjustedIndex: stream.index) ?? stream.index
+        if let index, index >= 0 {
             vlcUIProxy.setAudioTrack(.absolute(index))
         } else {
             vlcUIProxy.setAudioTrack(.auto)
@@ -156,6 +157,10 @@ extension VLCMediaPlayerProxy {
         @State
         private var lastBufferTraceSecond = -1
 
+        /// Times audio has been re-selected after VLC disabled it (#61)
+        @State
+        private var audioHealAttempts = 0
+
         #if DEBUG
         private let vlcDiagnosticLogger = VLCDiagnosticLogger()
         #endif
@@ -183,9 +188,7 @@ extension VLCMediaPlayerProxy {
 
             if !baseItem.isLiveStream {
                 configuration.startSeconds = startSeconds
-                if let index = item.selectedAudioStreamIndex, index >= 0 {
-                    configuration.audioIndex = .absolute(index)
-                } else if let index = mediaSource.defaultAudioStreamIndex, index >= 0 {
+                if let index = item.vlcAudioTrackIndex(forAdjustedIndex: item.selectedAudioStreamIndex), index >= 0 {
                     configuration.audioIndex = .absolute(index)
                 } else {
                     configuration.audioIndex = .auto
@@ -303,6 +306,24 @@ extension VLCMediaPlayerProxy {
                                 )
                             }
 
+                            // Fail audible: current track -1 with real tracks present
+                            // means VLC dropped the requested index (#61). Re-select
+                            // by position from VLC's own track list.
+                            if info.currentAudioTrack.index == -1, audioHealAttempts < 3 {
+                                let trackIndexes = info.audioTracks.map(\.index).filter { $0 >= 0 }
+                                if trackIndexes.isNotEmpty {
+                                    audioHealAttempts += 1
+                                    let position = playbackItem.audioStreams.firstIndex {
+                                        $0.index == playbackItem.selectedAudioStreamIndex
+                                    } ?? 0
+                                    let target = position < trackIndexes.count ? trackIndexes[position] : trackIndexes[0]
+                                    manager.logger.warning(
+                                        "VLC audio disabled with tracks \(trackIndexes) available, selecting \(target)"
+                                    )
+                                    proxy.setAudioTrack(.absolute(target))
+                                }
+                            }
+
                             if let proxy = manager.proxy as? any VideoMediaPlayerProxy {
                                 proxy.videoSize.value = info.videoSize
                             }
@@ -401,6 +422,7 @@ extension VLCMediaPlayerProxy {
                         lastReportedState = nil
                         stateDebounceTask?.cancel()
                         consecutiveBufferingCount = 0
+                        audioHealAttempts = 0
 
                         guard let playbackItem else { return }
 

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
@@ -326,6 +326,16 @@ extension VLCMediaPlayerProxy {
                                     consecutiveBufferingCount = 0
                                     lastPlayingTime = Date()
                                     manager.proxy?.isBuffering.value = false
+
+                                    // current index -1 with tracks available means VLC muted
+                                    // the audio because our requested index didn't match (#61)
+                                    let audioTracks = info.audioTracks
+                                        .map { "\($0.index):\($0.title)" }
+                                        .joined(separator: ", ")
+                                    manager.logger.trace(
+                                        "VLC audio tracks: [\(audioTracks)], current: \(info.currentAudioTrack.index)"
+                                    )
+
                                     await manager.setPlaybackRequestStatus(status: .playing)
                                 case .paused:
                                     await manager.setPlaybackRequestStatus(status: .paused)

--- a/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaPlayerProxy/MediaPlayerProxy+VLC.swift
@@ -9,6 +9,7 @@
 import Defaults
 import Foundation
 import JellyfinAPI
+import Logging
 import SwiftUI
 import VLCUI
 
@@ -115,6 +116,18 @@ class VLCMediaPlayerProxy: VideoMediaPlayerProxy,
     }
 }
 
+#if DEBUG
+/// Bridges libVLC's log callback into the app log for the #61 diagnosis
+private final class VLCDiagnosticLogger: VLCVideoPlayerLogger {
+
+    private let logger = Logger.swiftfin()
+
+    func vlcVideoPlayer(didLog message: String, at level: VLCVideoPlayer.LoggingLevel) {
+        logger.trace("VLC[\(level)]: \(message)")
+    }
+}
+#endif
+
 extension VLCMediaPlayerProxy {
 
     struct VLCPlayerView: View {
@@ -138,6 +151,14 @@ extension VLCMediaPlayerProxy {
         private var stateDebounceTask: Task<Void, Never>?
         @State
         private var lastReportedState: VLCUI.VLCVideoPlayer.State?
+
+        /// Last whole second a buffer-health trace was emitted for (#61)
+        @State
+        private var lastBufferTraceSecond = -1
+
+        #if DEBUG
+        private let vlcDiagnosticLogger = VLCDiagnosticLogger()
+        #endif
 
         /// Decode stall detection for VideoToolbox recovery
         @State
@@ -247,9 +268,21 @@ extension VLCMediaPlayerProxy {
             return configuration
         }
 
+        private func makePlayer(for playbackItem: MediaPlayerItem) -> VLCVideoPlayer {
+            let player = VLCVideoPlayer(configuration: vlcConfiguration(for: playbackItem))
+            #if DEBUG
+            // Surface libVLC's own messages (decoder/aout selection, errors)
+            // for the no-audio diagnosis in #61. Debug builds only; VLC log
+            // callbacks on device can distort playback timing
+            return player.logger(vlcDiagnosticLogger, level: .info)
+            #else
+            return player
+            #endif
+        }
+
         var body: some View {
             if let playbackItem = manager.playbackItem, manager.state != .stopped, !manager.isStopping {
-                VLCVideoPlayer(configuration: vlcConfiguration(for: playbackItem))
+                makePlayer(for: playbackItem)
                     .proxy(proxy)
                     .onSecondsUpdated { newSeconds, info in
                         Task { @MainActor in
@@ -258,6 +291,17 @@ extension VLCMediaPlayerProxy {
                             }
 
                             manager.seconds = newSeconds
+
+                            // Decode health for #61: played buffers flat at 0
+                            // while decoded blocks climb means the aout ate the
+                            // audio; both flat means the decoder never ran
+                            let seconds = Int(newSeconds.seconds)
+                            if seconds > 0, seconds % 10 == 0, seconds != lastBufferTraceSecond {
+                                lastBufferTraceSecond = seconds
+                                manager.logger.trace(
+                                    "VLC audio health @\(seconds)s: decodedBlocks=\(info.numberOfDecodedAudioBlocks) playedBuffers=\(info.numberOfPlayedAudioBuffers) lostBuffers=\(info.numberOfLostAudioBuffers) currentTrack=\(info.currentAudioTrack.index)"
+                                )
+                            }
 
                             if let proxy = manager.proxy as? any VideoMediaPlayerProxy {
                                 proxy.videoSize.value = info.videoSize

--- a/Shared/Objects/MediaPlayerManager/MediaProgressObserver.swift
+++ b/Shared/Objects/MediaPlayerManager/MediaProgressObserver.swift
@@ -124,13 +124,13 @@ class MediaProgressObserver: ViewModel, MediaPlayerObserver {
         Task {
             do {
                 var info = PlaybackStartInfo()
-                info.audioStreamIndex = item.selectedAudioStreamIndex
+                info.audioStreamIndex = item.serverAudioStreamIndex(forAdjustedIndex: item.selectedAudioStreamIndex)
                 info.itemID = item.baseItem.id
                 info.mediaSourceID = item.mediaSource.id
                 info.playSessionID = item.playSessionID
                 info.positionTicks = seconds?.ticks
                 info.sessionID = item.playSessionID
-                info.subtitleStreamIndex = item.selectedSubtitleStreamIndex
+                info.subtitleStreamIndex = item.serverSubtitleStreamIndex(forAdjustedIndex: item.selectedSubtitleStreamIndex)
 
                 let request = Paths.reportPlaybackStart(info)
                 let session = try requireSession()
@@ -187,14 +187,14 @@ class MediaProgressObserver: ViewModel, MediaPlayerObserver {
         Task {
             do {
                 var info = PlaybackProgressInfo()
-                info.audioStreamIndex = item.selectedAudioStreamIndex
+                info.audioStreamIndex = item.serverAudioStreamIndex(forAdjustedIndex: item.selectedAudioStreamIndex)
                 info.isPaused = isPaused
                 info.itemID = item.baseItem.id
                 info.mediaSourceID = item.mediaSource.id
                 info.playSessionID = item.playSessionID
                 info.positionTicks = seconds?.ticks
                 info.sessionID = item.playSessionID
-                info.subtitleStreamIndex = item.selectedSubtitleStreamIndex
+                info.subtitleStreamIndex = item.serverSubtitleStreamIndex(forAdjustedIndex: item.selectedSubtitleStreamIndex)
 
                 let request = Paths.reportPlaybackProgress(info)
                 let session = try requireSession()

--- a/Swiftfin tvOS Tests/MediaPlayerItemAudioSelectionTests.swift
+++ b/Swiftfin tvOS Tests/MediaPlayerItemAudioSelectionTests.swift
@@ -104,4 +104,95 @@ final class MediaPlayerItemAudioSelectionTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(item.selectedAudioStreamIndex ?? -1, 0)
         XCTAssertEqual(item.selectedAudioStreamIndex, item.audioStreams.first?.index)
     }
+
+    // MARK: audio-first containers (#61)
+
+    /// iTunes-style layout: audio is the first track in the container,
+    /// so its server index is 0 and VLC numbers it 0.
+    private func makeAudioFirstMediaSource(
+        defaultAudioStreamIndex: Int? = 0,
+        audioLanguages: [String] = ["eng"],
+        transcodingURL: String? = nil
+    ) -> MediaSourceInfo {
+        var mediaStreams: [MediaStream] = []
+
+        for (offset, language) in audioLanguages.enumerated() {
+            mediaStreams.append(
+                makeStream(index: offset, type: .audio, language: language, displayTitle: language)
+            )
+        }
+        mediaStreams.append(makeStream(index: audioLanguages.count, type: .video))
+        mediaStreams.append(makeStream(index: audioLanguages.count + 1, type: .subtitle))
+
+        var mediaSource = MediaSourceInfo()
+        mediaSource.transcodingURL = transcodingURL
+        mediaSource.mediaStreams = mediaStreams
+        mediaSource.defaultAudioStreamIndex = defaultAudioStreamIndex
+        return mediaSource
+    }
+
+    func testVLCIndexMapsToContainerOrderForAudioFirstFile() {
+        let originalPreferredLanguage = Defaults[.VideoPlayer.Audio.preferredLanguage]
+        defer { Defaults[.VideoPlayer.Audio.preferredLanguage] = originalPreferredLanguage }
+        Defaults[.VideoPlayer.Audio.preferredLanguage] = "zzz"
+
+        let item = makeItem(mediaSource: makeAudioFirstMediaSource())
+
+        // Adjusted space renumbers video-first, so the only audio stream is 1
+        XCTAssertEqual(item.selectedAudioStreamIndex, 1)
+        // VLC numbers by container order, where audio is track 0
+        XCTAssertEqual(item.vlcAudioTrackIndex(forAdjustedIndex: item.selectedAudioStreamIndex), 0)
+    }
+
+    func testVLCIndexUnchangedForVideoFirstFile() {
+        let originalPreferredLanguage = Defaults[.VideoPlayer.Audio.preferredLanguage]
+        defer { Defaults[.VideoPlayer.Audio.preferredLanguage] = originalPreferredLanguage }
+        Defaults[.VideoPlayer.Audio.preferredLanguage] = "zzz"
+
+        let mediaSource = makeMediaSource(defaultAudioStreamIndex: 1, audioLanguages: ["eng", "spa"])
+        let item = makeItem(mediaSource: mediaSource)
+
+        XCTAssertEqual(item.vlcAudioTrackIndex(forAdjustedIndex: 1), 1)
+        XCTAssertEqual(item.vlcAudioTrackIndex(forAdjustedIndex: 2), 2)
+    }
+
+    func testVLCIndexUnchangedForTranscode() {
+        let originalPreferredLanguage = Defaults[.VideoPlayer.Audio.preferredLanguage]
+        defer { Defaults[.VideoPlayer.Audio.preferredLanguage] = originalPreferredLanguage }
+        Defaults[.VideoPlayer.Audio.preferredLanguage] = "zzz"
+
+        // Server muxes the transcode video-first, so the adjusted index is
+        // already what VLC sees regardless of source container order
+        let mediaSource = makeAudioFirstMediaSource(transcodingURL: "https://example.com/transcode.m3u8")
+        let item = makeItem(mediaSource: mediaSource)
+
+        XCTAssertEqual(item.selectedAudioStreamIndex, 1)
+        XCTAssertEqual(item.vlcAudioTrackIndex(forAdjustedIndex: item.selectedAudioStreamIndex), 1)
+    }
+
+    func testMultiAudioAudioFirstMapsSecondTrack() {
+        let originalPreferredLanguage = Defaults[.VideoPlayer.Audio.preferredLanguage]
+        defer { Defaults[.VideoPlayer.Audio.preferredLanguage] = originalPreferredLanguage }
+        Defaults[.VideoPlayer.Audio.preferredLanguage] = "zzz"
+
+        // Server default is the second audio track (index 1 in server space)
+        let mediaSource = makeAudioFirstMediaSource(defaultAudioStreamIndex: 1, audioLanguages: ["eng", "spa"])
+        let item = makeItem(mediaSource: mediaSource)
+
+        // Selection maps the server default by position: spa is adjusted index 2
+        XCTAssertEqual(item.selectedAudioStreamIndex, 2)
+        XCTAssertEqual(
+            item.audioStreams.first(where: { $0.index == item.selectedAudioStreamIndex })?.language,
+            "spa"
+        )
+        // VLC's audio tracks are numbered [0, 1] in container order
+        XCTAssertEqual(item.vlcAudioTrackIndex(forAdjustedIndex: 2), 1)
+    }
+
+    func testVLCIndexNilForNilSelection() {
+        let mediaSource = makeMediaSource(defaultAudioStreamIndex: nil, audioLanguages: [])
+        let item = makeItem(mediaSource: mediaSource)
+
+        XCTAssertNil(item.vlcAudioTrackIndex(forAdjustedIndex: nil))
+    }
 }

--- a/Swiftfin tvOS Tests/MediaPlayerItemAudioSelectionTests.swift
+++ b/Swiftfin tvOS Tests/MediaPlayerItemAudioSelectionTests.swift
@@ -195,4 +195,50 @@ final class MediaPlayerItemAudioSelectionTests: XCTestCase {
 
         XCTAssertNil(item.vlcAudioTrackIndex(forAdjustedIndex: nil))
     }
+
+    // MARK: server-space reporting indexes
+
+    func testServerAudioIndexReversesAdjustedForAudioFirstFile() {
+        let item = makeItem(mediaSource: makeAudioFirstMediaSource())
+
+        // Adjusted audio is 1 (video-first renumbering); the server knows it as 0
+        XCTAssertEqual(item.serverAudioStreamIndex(forAdjustedIndex: 1), 0)
+    }
+
+    func testServerAudioIndexUnchangedForVideoFirstFile() {
+        let mediaSource = makeMediaSource(defaultAudioStreamIndex: 1, audioLanguages: ["eng", "spa"])
+        let item = makeItem(mediaSource: mediaSource)
+
+        XCTAssertEqual(item.serverAudioStreamIndex(forAdjustedIndex: 1), 1)
+        XCTAssertEqual(item.serverAudioStreamIndex(forAdjustedIndex: 2), 2)
+    }
+
+    func testServerAudioIndexTranscodeUsesSelectedTrack() {
+        // A transcode carries only the server-selected audio track, so the
+        // single adjusted index reports as that track's server index
+        let mediaSource = makeAudioFirstMediaSource(
+            defaultAudioStreamIndex: 1,
+            audioLanguages: ["eng", "spa"],
+            transcodingURL: "https://example.com/transcode.m3u8"
+        )
+        let item = makeItem(mediaSource: mediaSource)
+
+        XCTAssertEqual(item.serverAudioStreamIndex(forAdjustedIndex: 1), 1)
+
+        let defaultFirst = makeAudioFirstMediaSource(
+            defaultAudioStreamIndex: 0,
+            audioLanguages: ["eng", "spa"],
+            transcodingURL: "https://example.com/transcode.m3u8"
+        )
+        let itemDefaultFirst = makeItem(mediaSource: defaultFirst)
+
+        XCTAssertEqual(itemDefaultFirst.serverAudioStreamIndex(forAdjustedIndex: 1), 0)
+    }
+
+    func testServerAudioIndexNilPassesThrough() {
+        let mediaSource = makeMediaSource(defaultAudioStreamIndex: nil, audioLanguages: [])
+        let item = makeItem(mediaSource: mediaSource)
+
+        XCTAssertNil(item.serverAudioStreamIndex(forAdjustedIndex: nil))
+    }
 }

--- a/Swiftfin tvOS Tests/MediaPlayerItemSubtitleSelectionTests.swift
+++ b/Swiftfin tvOS Tests/MediaPlayerItemSubtitleSelectionTests.swift
@@ -17,12 +17,13 @@ final class MediaPlayerItemSubtitleSelectionTests: XCTestCase {
 
     private let testURL = URL(string: "https://example.com/video")!
 
-    private func makeStream(index: Int, type: MediaStreamType, language: String? = nil) -> MediaStream {
+    private func makeStream(index: Int, type: MediaStreamType, language: String? = nil, isExternal: Bool = false) -> MediaStream {
         var stream = MediaStream()
         stream.index = index
         stream.type = type
         stream.language = language
         stream.displayTitle = language
+        stream.isExternal = isExternal
         return stream
     }
 
@@ -42,6 +43,19 @@ final class MediaPlayerItemSubtitleSelectionTests: XCTestCase {
         ]
         mediaSource.defaultAudioStreamIndex = 3
         mediaSource.defaultSubtitleStreamIndex = defaultSubtitleStreamIndex
+        mediaSource.transcodingURL = transcoding ? "/transcode" : nil
+        return mediaSource
+    }
+
+    /// Arbitrary stream layouts for container-order cases.
+    private func makeMediaSource(
+        streams: [MediaStream],
+        defaultAudioStreamIndex: Int? = nil,
+        transcoding: Bool = false
+    ) -> MediaSourceInfo {
+        var mediaSource = MediaSourceInfo()
+        mediaSource.mediaStreams = streams
+        mediaSource.defaultAudioStreamIndex = defaultAudioStreamIndex
         mediaSource.transcodingURL = transcoding ? "/transcode" : nil
         return mediaSource
     }
@@ -183,4 +197,100 @@ final class MediaPlayerItemSubtitleSelectionTests: XCTestCase {
 
         XCTAssertEqual(index, 3)
     }
+
+    // MARK: container-order VLC mapping (#61)
+
+    func testVLCSubtitleIndexMapsToContainerOrderDirectPlay() {
+        // Container order is video(0), subtitles(1, 2), audio(3, 4), so the
+        // adjusted subtitle indexes 3 and 4 are VLC tracks 1 and 2
+        let item = makeItem(mediaSource: makeMediaSource(), preferred: nil)
+
+        XCTAssertEqual(item.vlcSubtitleTrackIndex(forAdjustedIndex: 3), 1)
+        XCTAssertEqual(item.vlcSubtitleTrackIndex(forAdjustedIndex: 4), 2)
+    }
+
+    func testVLCSubtitleIndexUnchangedWhenSubsLast() {
+        // video(0), audio(1), subtitles(2, 3): adjusted order matches the container
+        let mediaSource = makeMediaSource(
+            streams: [
+                makeStream(index: 0, type: .video),
+                makeStream(index: 1, type: .audio, language: "eng"),
+                makeStream(index: 2, type: .subtitle, language: "eng"),
+                makeStream(index: 3, type: .subtitle, language: "spa"),
+            ],
+            defaultAudioStreamIndex: 1
+        )
+        let item = makeItem(mediaSource: mediaSource, preferred: nil)
+
+        XCTAssertEqual(item.vlcSubtitleTrackIndex(forAdjustedIndex: 2), 2)
+        XCTAssertEqual(item.vlcSubtitleTrackIndex(forAdjustedIndex: 3), 3)
+    }
+
+    func testVLCSubtitleIndexUnchangedForAudioFirstFileWithSubsLast() {
+        // Audio-first shifts video and audio in the adjusted space, but the
+        // subtitle track sits last in the container either way
+        let mediaSource = makeMediaSource(
+            streams: [
+                makeStream(index: 0, type: .audio, language: "eng"),
+                makeStream(index: 1, type: .video),
+                makeStream(index: 2, type: .subtitle, language: "eng"),
+            ],
+            defaultAudioStreamIndex: 0
+        )
+        let item = makeItem(mediaSource: mediaSource, preferred: nil)
+
+        XCTAssertEqual(item.vlcSubtitleTrackIndex(forAdjustedIndex: 2), 2)
+    }
+
+    func testVLCSubtitleIndexExternalPassesThrough() {
+        // External subs load as playback slaves, which VLC numbers after the
+        // container tracks - the same relative spot the adjusted space uses
+        let mediaSource = makeMediaSource(
+            streams: [
+                makeStream(index: 0, type: .video),
+                makeStream(index: 1, type: .subtitle, language: "eng"),
+                makeStream(index: 2, type: .audio, language: "eng"),
+                makeStream(index: 3, type: .subtitle, language: "spa", isExternal: true),
+            ],
+            defaultAudioStreamIndex: 2
+        )
+        let item = makeItem(mediaSource: mediaSource, preferred: nil)
+
+        // Internal sub at adjusted 2 maps to container index 1; external stays put
+        XCTAssertEqual(item.vlcSubtitleTrackIndex(forAdjustedIndex: 2), 1)
+        XCTAssertEqual(item.vlcSubtitleTrackIndex(forAdjustedIndex: 3), 3)
+    }
+
+    func testVLCSubtitleIndexExternalPassesThroughAudioFirst() {
+        let mediaSource = makeMediaSource(
+            streams: [
+                makeStream(index: 0, type: .audio, language: "eng"),
+                makeStream(index: 1, type: .video),
+                makeStream(index: 2, type: .subtitle, language: "eng"),
+                makeStream(index: 3, type: .subtitle, language: "spa", isExternal: true),
+            ],
+            defaultAudioStreamIndex: 0
+        )
+        let item = makeItem(mediaSource: mediaSource, preferred: nil)
+
+        XCTAssertEqual(item.vlcSubtitleTrackIndex(forAdjustedIndex: 2), 2)
+        XCTAssertEqual(item.vlcSubtitleTrackIndex(forAdjustedIndex: 3), 3)
+    }
+
+    func testVLCSubtitleIndexOffAndNilPassThrough() {
+        let item = makeItem(mediaSource: makeMediaSource(), preferred: nil)
+
+        XCTAssertEqual(item.vlcSubtitleTrackIndex(forAdjustedIndex: -1), -1)
+        XCTAssertNil(item.vlcSubtitleTrackIndex(forAdjustedIndex: nil))
+    }
+
+    func testVLCSubtitleIndexUnchangedForTranscode() {
+        // Transcoded subs arrive as extracted slaves aligned with the
+        // adjusted order, so the index passes through like the audio path
+        let item = makeItem(mediaSource: makeMediaSource(transcoding: true), preferred: nil)
+
+        XCTAssertEqual(item.vlcSubtitleTrackIndex(forAdjustedIndex: 2), 2)
+        XCTAssertEqual(item.vlcSubtitleTrackIndex(forAdjustedIndex: 3), 3)
+    }
+
 }

--- a/Swiftfin tvOS Tests/MediaPlayerItemSubtitleSelectionTests.swift
+++ b/Swiftfin tvOS Tests/MediaPlayerItemSubtitleSelectionTests.swift
@@ -293,4 +293,48 @@ final class MediaPlayerItemSubtitleSelectionTests: XCTestCase {
         XCTAssertEqual(item.vlcSubtitleTrackIndex(forAdjustedIndex: 3), 3)
     }
 
+    // MARK: server-space reporting indexes
+
+    func testServerSubtitleIndexReversesAdjustedDirectPlay() {
+        let item = makeItem(mediaSource: makeMediaSource(), preferred: nil)
+
+        XCTAssertEqual(item.serverSubtitleStreamIndex(forAdjustedIndex: 3), 1)
+        XCTAssertEqual(item.serverSubtitleStreamIndex(forAdjustedIndex: 4), 2)
+    }
+
+    func testServerSubtitleIndexReversesAdjustedTranscode() {
+        // Transcode renumbers to video(0), audio(1), subtitles(2, 3); the
+        // server still knows those subs as indexes 1 and 2
+        let item = makeItem(mediaSource: makeMediaSource(transcoding: true), preferred: nil)
+
+        XCTAssertEqual(item.serverSubtitleStreamIndex(forAdjustedIndex: 2), 1)
+        XCTAssertEqual(item.serverSubtitleStreamIndex(forAdjustedIndex: 3), 2)
+    }
+
+    func testServerSubtitleIndexSurvivesDroppedStreams() {
+        // The embedded image stream is dropped from the adjusted space
+        // entirely, shifting positions; server indexes must come from the
+        // original streams, not from counting
+        let mediaSource = makeMediaSource(
+            streams: [
+                makeStream(index: 0, type: .video),
+                makeStream(index: 1, type: .audio, language: "eng"),
+                makeStream(index: 2, type: .embeddedImage),
+                makeStream(index: 3, type: .subtitle, language: "eng"),
+                makeStream(index: 4, type: .subtitle, language: "spa", isExternal: true),
+            ],
+            defaultAudioStreamIndex: 1
+        )
+        let item = makeItem(mediaSource: mediaSource, preferred: nil)
+
+        XCTAssertEqual(item.serverSubtitleStreamIndex(forAdjustedIndex: 2), 3)
+        XCTAssertEqual(item.serverSubtitleStreamIndex(forAdjustedIndex: 3), 4)
+    }
+
+    func testServerSubtitleIndexOffAndNilPassThrough() {
+        let item = makeItem(mediaSource: makeMediaSource(), preferred: nil)
+
+        XCTAssertEqual(item.serverSubtitleStreamIndex(forAdjustedIndex: -1), -1)
+        XCTAssertNil(item.serverSubtitleStreamIndex(forAdjustedIndex: nil))
+    }
 }


### PR DESCRIPTION
Fixes #61

Video played but audio was silent on MP4s that store the audio track before the video track (common in iTunes-style libraries). Reefy's track index mapping assumed video always comes first in the container, so it asked VLC for an audio track number that didn't exist — and VLC's response to a bad track number is to silently disable audio.

What's in here:

- Map the selected audio track back to its real container position before handing it to VLC (direct play only; transcodes are muxed video-first by the server and pass through unchanged)
- Same mapping for internal subtitle tracks; external subs still align count-based since VLC numbers slaves after container tracks
- Honor the server's default audio choice by position instead of comparing indexes across two different numbering spaces
- Report server-space stream indexes in playback progress so resume state stays correct
- Fail-audible backstop: if VLC reports audio disabled while real tracks exist, re-select from VLC's own track list (max 3 attempts per item)

Tests cover the new mapping paths in both audio and subtitle selection. Verified on device against the reporter's original file: audio-first MP4 now plays with sound on direct play.

Note for later: upstream Swiftfin's `MediaTrackIndexMap` (PR #1882) solves this same problem more generally — these helpers should be dropped in favor of it whenever that port happens.
